### PR TITLE
fix(detect_page_type): change type detection to be exact

### DIFF
--- a/src/indu_doc/common_page_utils.py
+++ b/src/indu_doc/common_page_utils.py
@@ -80,7 +80,7 @@ def detect_page_type(page: pymupdf.Page) -> Optional[PageType]:
                 for s in line["spans"]:  # iterate through the text spans
                     if s["size"] > 20:  # if fontsize > 20 pt
                         for pt in PageType:
-                            if pt.value.lower() in s["text"].lower():
+                            if pt.value.strip().lower() == s["text"].strip().lower():
                                 logger.info(
                                     f"Page {page.number + 1} is of type {pt.name}"
                                 )


### PR DESCRIPTION
Behavior is the same, only these pages are different 
Page 302: Old: PageType.CABLE_PLAN, New: None
Page 303: Old: PageType.CABLE_PLAN, New: None
Page 304: Old: PageType.CABLE_PLAN, New: None